### PR TITLE
Use "type": "wp-cli-package" to designate this as a WP-CLI package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "anhskohbo/wp-cli-themecheck",
     "description": "Run Themecheck in WP_CLI",
+    "type": "wp-cli-package",
     "homepage": "https://github.com/anhskohbo/wp-cli-themecheck",
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/2567
