### PR TITLE
Support for non-zero exit status

### DIFF
--- a/command.php
+++ b/command.php
@@ -87,10 +87,14 @@ if ( ! class_exists( 'WP_CLI_Themecheck_Command' ) ) :
 				}
 			}
 
+			$required_count = ! empty( $this->stack_errors['REQUIRED'] ) ? count( $this->stack_errors['REQUIRED'] ) : 0;
+			$warning_count = ! empty( $this->stack_errors['WARNING'] ) ? count( $this->stack_errors['WARNING'] ) : 0;
+			$total_errors = $required_count + $warning_count;
+
 			if ( $is_success ) {
-				WP_CLI::success( sprintf( 'Congratulations! %s is passed the tests!', $theme->get( 'Name' ) ) );
+				WP_CLI::success( sprintf( 'Congratulations! %s passed the tests!', $theme->get( 'Name' ) ) );
 			} else {
-				WP_CLI::error( sprintf( 'One or more errors were found for %s!', $theme->get( 'Name' ) ), false );
+				WP_CLI::error( sprintf( '%d error(s) found for %s!', $total_errors, $theme->get( 'Name' ) ), $total_errors );
 			}
 		}
 

--- a/command.php
+++ b/command.php
@@ -239,12 +239,26 @@ if ( ! class_exists( 'WP_CLI_Themecheck_Command' ) ) :
 			}
 
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+			$plugin = 'theme-check/theme-check.php';
 
-			if ( array_key_exists( 'theme-check/theme-check.php', get_plugins() ) ) {
-				WP_CLI::error( "Please activate the Theme Check plugin: wp plugin activate theme-check" );
+			if ( array_key_exists( $plugin, get_plugins() ) ) {
+				$command = array( array( 'plugin', 'activate', 'theme-check' ), array() );
+				$error_msg = "Themecheck needs to be activated. Try 'wp plugin activate theme-check'.";
+			} else {
+				$command = array( array( 'plugin', 'install', 'theme-check' ), array( 'activate' => true ) );
+				$error_msg = "Themecheck needs to be installed. Try 'wp plugin install theme-check --activate'.";
 			}
 
-			WP_CLI::error( "Please install and activate the Theme Check plugin: wp plugin install theme-check --activate" );
+			WP_CLI::error( $error_msg . "\n" );
+			$choose = cli\choose( 'Do you want run above command right now' );
+
+			if ( 'y' !== $choose ) {
+				exit;
+			}
+
+			WP_CLI::line();
+			WP_CLI::run_command( $command[0], $command[1] );
+			WP_CLI::line();
 		}
 	}
 

--- a/command.php
+++ b/command.php
@@ -249,7 +249,7 @@ if ( ! class_exists( 'WP_CLI_Themecheck_Command' ) ) :
 				$error_msg = "Themecheck needs to be installed. Try 'wp plugin install theme-check --activate'.";
 			}
 
-			WP_CLI::error( $error_msg . "\n", false );
+			WP_CLI::error( $error_msg . "\n" );
 			$choose = cli\choose( 'Do you want run above command right now' );
 
 			if ( 'y' !== $choose ) {

--- a/command.php
+++ b/command.php
@@ -239,26 +239,12 @@ if ( ! class_exists( 'WP_CLI_Themecheck_Command' ) ) :
 			}
 
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
-			$plugin = 'theme-check/theme-check.php';
 
-			if ( array_key_exists( $plugin, get_plugins() ) ) {
-				$command = array( array( 'plugin', 'activate', 'theme-check' ), array() );
-				$error_msg = "Themecheck needs to be activated. Try 'wp plugin activate theme-check'.";
-			} else {
-				$command = array( array( 'plugin', 'install', 'theme-check' ), array( 'activate' => true ) );
-				$error_msg = "Themecheck needs to be installed. Try 'wp plugin install theme-check --activate'.";
+			if ( array_key_exists( 'theme-check/theme-check.php', get_plugins() ) ) {
+				WP_CLI::error( "Please activate the Theme Check plugin: wp plugin activate theme-check" );
 			}
 
-			WP_CLI::error( $error_msg . "\n" );
-			$choose = cli\choose( 'Do you want run above command right now' );
-
-			if ( 'y' !== $choose ) {
-				exit;
-			}
-
-			WP_CLI::line();
-			WP_CLI::run_command( $command[0], $command[1] );
-			WP_CLI::line();
+			WP_CLI::error( "Please install and activate the Theme Check plugin: wp plugin install theme-check --activate" );
 		}
 	}
 

--- a/command.php
+++ b/command.php
@@ -35,6 +35,9 @@ if ( ! class_exists( 'WP_CLI_Themecheck_Command' ) ) :
 		 * [--skip-recommended]
 		 * : Suppress RECOMMENDED.
 		 *
+		 * [--interactive]
+		 * : Prompt user for input (default).
+		 *
 		 * ## EXAMPLES
 		 *
 		 *     $ wp themecheck --theme="twentysixteen"
@@ -43,13 +46,16 @@ if ( ! class_exists( 'WP_CLI_Themecheck_Command' ) ) :
 		 */
 		public function __invoke( $args, $assoc_args ) {
 
-			$this->before_themecheck();
+			$interactive = (bool) Utils\get_flag_value( $assoc_args, 'interactive', true );
+			$this->before_themecheck( $interactive );
 
 			require_once WP_PLUGIN_DIR . '/theme-check/checkbase.php';
 			require_once WP_PLUGIN_DIR . '/theme-check/main.php';
 
 			if ( Utils\get_flag_value( $assoc_args, 'theme' ) ) {
 				$themename = Utils\get_flag_value( $assoc_args, 'theme' );
+			} elseif ( ! $interactive ) {
+				$themename = get_stylesheet();
 			} else {
 				$themename = $this->choices_theme();
 			}
@@ -61,7 +67,7 @@ if ( ! class_exists( 'WP_CLI_Themecheck_Command' ) ) :
 			} elseif ( is_dir( $guest_path ) ) {
 				$themepath = trailingslashit( $guest_path );
 			} else {
-				WP_CLI::error( 'Unable find theme with name "' . $themename . '"' );
+				WP_CLI::error( 'Unable find theme named "' . $themename . '"' );
 			}
 
 			// Run themecheck.
@@ -182,7 +188,7 @@ if ( ! class_exists( 'WP_CLI_Themecheck_Command' ) ) :
 				$themes[ $id ] = $theme->get( 'Name' );
 			}
 
-			return cli\menu( $themes, wp_get_theme()->template, 'Choose a theme' );
+			return cli\menu( $themes, get_stylesheet(), 'Choose a theme' );
 		}
 
 		/**
@@ -231,25 +237,26 @@ if ( ! class_exists( 'WP_CLI_Themecheck_Command' ) ) :
 		}
 
 		/**
-		 * Make sure themecheck installed.
+		 * Make sure the Theme Check plugin is installed.
+		 *
+		 * @param bool $interactive Prompt user before exiting.
 		 */
-		private function before_themecheck() {
+		private function before_themecheck( $interactive ) {
 			if ( class_exists( 'ThemeCheckMain' ) ) {
 				return true;
 			}
 
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
-			$plugin = 'theme-check/theme-check.php';
 
-			if ( array_key_exists( $plugin, get_plugins() ) ) {
+			if ( array_key_exists( 'theme-check/theme-check.php', get_plugins() ) ) {
 				$command = array( array( 'plugin', 'activate', 'theme-check' ), array() );
-				$error_msg = "Themecheck needs to be activated. Try 'wp plugin activate theme-check'.";
+				$error_msg = "The Theme Check plugin must be activated.\n\n\tRun: wp plugin activate theme-check\n";
 			} else {
 				$command = array( array( 'plugin', 'install', 'theme-check' ), array( 'activate' => true ) );
-				$error_msg = "Themecheck needs to be installed. Try 'wp plugin install theme-check --activate'.";
+				$error_msg = "The Theme Check plugin must be installed and activated.\n\n\tRun: wp plugin install theme-check --activate\n";
 			}
 
-			WP_CLI::error( $error_msg . "\n" );
+			WP_CLI::error( $error_msg, ! $interactive );
 			$choose = cli\choose( 'Do you want run above command right now' );
 
 			if ( 'y' !== $choose ) {


### PR DESCRIPTION
Implements #4 

- Only exit with status `0` when all tests pass
- Use the total number of `REQUIRED` and `WARNING` errors as the exit status code
- ~Remove interactive prompt for Theme Check plugin dependency that blocks automated workflows~
- Add `--interactive` flag that is `true` by default but can be negated with `--no-interactive`
- Exit with status `1` when the Theme Check plugin dependency is not met