### PR TITLE
Fix allow optional semicolon on regex

### DIFF
--- a/command.php
+++ b/command.php
@@ -163,7 +163,7 @@ if ( ! class_exists( 'WP_CLI_Themecheck_Command' ) ) :
 			) );
 
 			// Build logs report.
-			$log_pattern = '/(<span\sclass=.*>(REQUIRED|WARNING|RECOMMENDED|INFO)<\/span>\s?:)/i';
+			$log_pattern = '/(<span\sclass=.*>(REQUIRED|WARNING|RECOMMENDED|INFO)<\/span>\s?:?)/i';
 			$stack_errors = array( 'REQUIRED' => array(), 'WARNING' => array(), 'RECOMMENDED' => array(), 'INFO' => array() );
 
 			foreach ( $themechecks as $check ) {


### PR DESCRIPTION
WordPress Theme check messages are sometimes inconsistent in formatting, `:`(semicolon) might be missing on some.
This should better catch messages that don't always have a `:` present after the span.

The critical target is the `span` tag, the subsequent formatting should be optional.

@anhskohbo Let me know what you think, as at the moment we encountered some issues and this should solve those.

Thank you! 